### PR TITLE
Fix for encoding issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,27 @@
 const awsServerlessExpress = require('aws-serverless-express');
 const app = require('./server');
-const server = awsServerlessExpress.createServer(app);
+
+const binaryMimeTypes = [
+  'application/gzip',
+  'application/javascript',
+  'application/json',
+  'application/octet-stream',
+  'application/xml',
+  'font/eot',
+  'font/opentype',
+  'font/otf',
+  'image/jpeg',
+  'image/png',
+  'image/svg+xml',
+  'text/comma-separated-values',
+  'text/css',
+  'text/html',
+  'text/javascript',
+  'text/plain',
+  'text/text',
+  'text/xml'
+];
+
+const server = awsServerlessExpress.createServer(app, null, binaryMimeTypes);
 
 exports.handler = (event, context) => awsServerlessExpress.proxy(server, event, context);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7509,11 +7509,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7530,7 +7532,8 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
@@ -7659,6 +7662,7 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }


### PR DESCRIPTION
It looks like the next.js update resulted in the response being encoded, and the API Gateway was not ready for this, which resulted in an ERR_CONTENT_DECODING_FAILED response in the browser.

Passing mimetypes to aws-serverless-express with application/gzip fixes this.